### PR TITLE
Update Azure logo

### DIFF
--- a/app/assets/images/svg/vendor-azure.svg
+++ b/app/assets/images/svg/vendor-azure.svg
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1"
-	 id="svg2" inkscape:version="0.48.5 r10040" sodipodi:docname="windows.svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="660.4 0 100 100"
-	 enable-background="new 660.4 0 100 100" xml:space="preserve" width="5cm" height="5cm">
-<path id="path13" inkscape:connector-curvature="0" fill="#0DADEA" d="M660.4,14.3l41-5.6v39.5h-41L660.4,14.3z M701.4,53.3v39.1
-	l-41-5.6l0-33.5L701.4,53.3L701.4,53.3L701.4,53.3z M705.9,8.1l54.5-7.5v47.6h-54.5V8.1z M760.4,53.3v47.2L705.9,93V53.3H760.4z"/>
+	 id="svg8" inkscape:version="0.92.1 r15371" sodipodi:docname="Azurey.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 55.9 43.2"
+	 style="enable-background:new 0 0 55.9 43.2;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#0089D6;}
+</style>
+<sodipodi:namedview  bordercolor="#666666" borderopacity="1.0" fit-margin-bottom="0" fit-margin-left="0" fit-margin-right="0" fit-margin-top="0" id="base" inkscape:current-layer="layer1" inkscape:cx="67.4659" inkscape:cy="38.024323" inkscape:document-units="mm" inkscape:pagecheckerboard="true" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="781" inkscape:window-maximized="0" inkscape:window-width="930" inkscape:window-x="667" inkscape:window-y="117" inkscape:zoom="6.5246067" pagecolor="#ffffff" showgrid="false">
+	</sodipodi:namedview>
+<g id="layer1" transform="translate(677.9313,-313.85407)" inkscape:groupmode="layer" inkscape:label="Layer 1">
+	<g id="layer1-1" transform="matrix(0.03978217,0,0,0.03978217,-658.51488,317.36166)" inkscape:label="Layer 1">
+		<path id="path21" inkscape:connector-curvature="0" class="st0" d="M160.7,940.1c180.2-31.8,329-58.2,330.7-58.5l3.1-0.7
+			L324.4,678.6c-93.6-111.3-170.1-202.8-170.1-203.3c0-1,175.7-484.7,176.6-486.4c0.3-0.6,119.9,205.8,289.8,500.3
+			c159.1,275.7,290.2,503,291.4,505.1l2.2,3.9L373.7,998l-540.6-0.1C-166.9,998,160.7,940.1,160.7,940.1z M-488.1,878.4
+			c0-0.3,80.2-139.4,178.1-309.2l178.1-308.7L75.7,86.3C189.9-9.5,283.6-88,284-88.2c0.4-0.1-1.1,3.6-3.3,8.4
+			C278.5-75,177,142.6,55.3,403.7l-221.4,474.8l-161,0.2C-415.6,878.8-488.1,878.7-488.1,878.4z"/>
+	</g>
+</g>
 </svg>


### PR DESCRIPTION
This PR replaces the Microsoft Azure logo to the current version

Old
<img width="143" alt="screen shot 2019-01-15 at 1 05 10 pm" src="https://user-images.githubusercontent.com/1287144/51201530-4fa22e80-18ca-11e9-852b-48af3bfedad7.png">

New
<img width="149" alt="screen shot 2019-01-15 at 12 32 34 pm" src="https://user-images.githubusercontent.com/1287144/51201531-4fa22e80-18ca-11e9-8ef1-b7b1e67bfbd5.png">
