### PR TITLE
Add a quadicon definition into automation manager decorators

### DIFF
--- a/app/decorators/manageiq/providers/automation_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager_decorator.rb
@@ -1,17 +1,35 @@
-module ManageIQ::Providers
-  class AutomationManagerDecorator < MiqDecorator
-    def self.fonticon
-      nil
-    end
+class ManageIQ::Providers::AutomationManagerDecorator < MiqDecorator
+  def self.fonticon
+    nil
+  end
 
-    def fileicon
-      "svg/vendor-#{image_name.downcase}.svg"
-    end
+  def fileicon
+    "svg/vendor-#{image_name.downcase}.svg"
+  end
 
-    def single_quad
-      {
-        :fileicon => fileicon
-      }
-    end
+  def single_quad
+    {
+      :fileicon => fileicon
+    }
+  end
+
+  def quadicon
+    icon = {
+      :top_left     => {
+        :text    => t = inventory_root_groups.size,
+        :tooltip => n_("%{number} Inventory Root Group", "%{number} Inventory Root Groups", t) % {:number => t}
+      },
+      :top_right    => {
+        :text    => t = configuration_scripts.size,
+        :tooltip => n_("%{number} Template", "%{number} Templates", t) % {:number => t}
+      },
+      :bottom_left  => {
+        :fileicon => fileicon,
+        :tooltip  => ui_lookup(:model => type)
+      },
+      :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
+    }
+    icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
+    icon
   end
 end


### PR DESCRIPTION
Specification of the quadrants taken from the issue below. Bottom line is same as usual, the top two numbers are inventory root groups and configuration scripts.

**Before:**
![screenshot from 2019-02-20 10-49-57](https://user-images.githubusercontent.com/649130/53082513-49245980-34fd-11e9-9ca3-e795cb182885.png)

**After:**
![screenshot from 2019-02-20 10-48-55](https://user-images.githubusercontent.com/649130/53082463-2f831200-34fd-11e9-91ac-10351069fde1.png)

Please review @slemrmartin

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5188