### PR TITLE
Change AuthPrivateKey decorator to Authentication decorator

### DIFF
--- a/app/decorators/authentication_decorator.rb
+++ b/app/decorators/authentication_decorator.rb
@@ -1,4 +1,4 @@
-class AuthPrivateKeyDecorator < MiqDecorator
+class AuthenticationDecorator < MiqDecorator
   def self.fonticon
     'ff ff-cloud-keys'
   end


### PR DESCRIPTION
`Authentication` is the base class, `AuthPrivateKey` a child.
Previously (https://github.com/ManageIQ/manageiq/pull/18633) `CloudManager::AuthKeyPair` inherited from `AuthPrivateKey`, but changed to `Authentication` now.

So, moving the decorator to cover the whole base class.
(Not seeing any problem with `AuthToken`, `AuthUseridPassword`, and `ManageIQ::Providers::AutomationManager::Authentication` also gaining a decorator because of this.)

(Fixes failing travis on ui-classic master:
```
  1) AuthKeyPairCloudController#report_data when tile mode is selected returns key pairs with quadicons
     Failure/Error: expect(results['data']['rows'][0]['quad']).to have_key('fonticon')
       expected  to respond to `has_key?`
     # ./spec/controllers/auth_key_pair_cloud_controller_spec.rb:98
```
)

Cc @skateman , @agrare 