### PR TITLE
Travis - update postgres to 10, to match manageiq repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ rvm:
 sudo: false
 cache: bundler
 addons:
-  postgresql: '9.4'
+  postgresql: '10'
 install: bin/setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: ruby
 rvm:
 - 2.4.5


### PR DESCRIPTION
Hoping this also fixes the `bin/setup` errror:

```
The version of PostgreSQL being connected to is incompatible with ManageIQ (10 required)
Couldn't drop database 'vmdb_test'
rails aborted!
The version of PostgreSQL being connected to is incompatible with ManageIQ (10 required)
/home/travis/build/ManageIQ/manageiq-decorators/spec/manageiq/config/initializers/postgres_required_versions.rb:8:in `initialize'
...
Tasks: TOP => app:db:drop:_unsafe
(See full trace by running task with --trace)
```