### PR TITLE
Replace IsoImage icon from network-card to file-iso-o

### DIFF
--- a/app/decorators/iso_image_decorator.rb
+++ b/app/decorators/iso_image_decorator.rb
@@ -1,5 +1,5 @@
 class IsoImageDecorator < MiqDecorator
   def self.fonticon
-    'ff ff-network-card'
+    'ff ff-file-iso-o'
   end
 end


### PR DESCRIPTION
It makes a little more sense and also can help me get rid of some extra nodes in the pxe trees.