### PR TITLE
Drop the ability to chose between quadicon and single_quad

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -25,10 +25,4 @@ class HostDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fonticon => fonticon
-    }
-  end
 end

--- a/app/decorators/manageiq/providers/automation_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager_decorator.rb
@@ -7,12 +7,6 @@ class ManageIQ::Providers::AutomationManagerDecorator < MiqDecorator
     "svg/vendor-#{image_name.downcase}.svg"
   end
 
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
-
   def quadicon
     icon = {
       :top_left     => {

--- a/app/decorators/manageiq/providers/cloud_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager_decorator.rb
@@ -30,10 +30,4 @@ class ManageIQ::Providers::CloudManagerDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/manageiq/providers/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/container_manager_decorator.rb
@@ -30,10 +30,4 @@ class ManageIQ::Providers::ContainerManagerDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/manageiq/providers/infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/infra_manager_decorator.rb
@@ -30,10 +30,4 @@ class ManageIQ::Providers::InfraManagerDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/manageiq/providers/network_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/network_manager_decorator.rb
@@ -30,10 +30,4 @@ class ManageIQ::Providers::NetworkManagerDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/physical_infra_manager_decorator.rb
@@ -27,10 +27,4 @@ class ManageIQ::Providers::PhysicalInfraManagerDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/manageiq/providers/storage_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager_decorator.rb
@@ -42,10 +42,4 @@ class ManageIQ::Providers::StorageManagerDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/miq_template_decorator.rb
+++ b/app/decorators/miq_template_decorator.rb
@@ -26,10 +26,4 @@ class MiqTemplateDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/physical_server_decorator.rb
+++ b/app/decorators/physical_server_decorator.rb
@@ -22,10 +22,4 @@ class PhysicalServerDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/decorators/physical_switch_decorator.rb
+++ b/app/decorators/physical_switch_decorator.rb
@@ -19,11 +19,4 @@ class PhysicalSwitchDecorator < MiqDecorator
       :bottom_right => QuadiconHelper.health_state(health_state)
     }
   end
-
-  def single_quad
-    {
-      :fonticon => fonticon,
-      :tooltip  => ui_lookup(:model => type),
-    }
-  end
 end

--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -23,12 +23,6 @@ class StorageDecorator < MiqDecorator
     }
   end
 
-  def single_quad
-    {
-      :piechart => percent
-    }
-  end
-
   private
 
   def percent

--- a/app/decorators/vm_decorator.rb
+++ b/app/decorators/vm_decorator.rb
@@ -31,10 +31,4 @@ class VmDecorator < MiqDecorator
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end
-
-  def single_quad
-    {
-      :fileicon => fileicon
-    }
-  end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -115,16 +115,8 @@ module QuadiconHelper
   end
 
   def quadicon_hash(item)
-    settings_key = item.class.try(:decorate).try(:to_s).try(:chomp, 'Decorator').try(:demodulize).try(:underscore).try(:to_sym)
-    # Quadicons should be displayed when explicitly set or when the user is on the policy simulation screen
-    quad_method = if settings(:quadicons, settings_key) || !!@policy_sim
-                    :quadicon
-                  else
-                    :single_quad
-                  end
-    quad_icon = item.try(:decorate).try(quad_method)
-    # Fall back to a single quad if a quadicon is not available
-    quad_icon = item.try(:decorate).try(:single_quad) if quad_icon.nil? && quad_method == :quadicon
+    # Try to build the quadicon and if not available, fall back to single_quad
+    quad_icon = item.try(:decorate).try(:quadicon) || item.try(:decorate).try(:single_quad)
 
     # Alter the quadicon's bottom-right quadrant on the policy simulation screen
     if !!@policy_sim && session[:policies].present?


### PR DESCRIPTION
As discussed in https://github.com/ManageIQ/manageiq-ui-classic/issues/6252, we're dropping the option to select what kind of icons should we render in GTLs if both quadicon and single_quad are available. This allows us to get rid of some `single_quad` definitions and simplifies the code a lot.