### PR TITLE
Rename single_quad definitions to quadicon

### DIFF
--- a/app/decorators/authentication_decorator.rb
+++ b/app/decorators/authentication_decorator.rb
@@ -3,7 +3,7 @@ class AuthenticationDecorator < MiqDecorator
     'ff ff-cloud-keys'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/availability_zone_decorator.rb
+++ b/app/decorators/availability_zone_decorator.rb
@@ -3,7 +3,7 @@ class AvailabilityZoneDecorator < MiqDecorator
     'pficon pficon-zone'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_network_decorator.rb
+++ b/app/decorators/cloud_network_decorator.rb
@@ -3,7 +3,7 @@ class CloudNetworkDecorator < MiqDecorator
     'ff ff-cloud-network'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_object_store_container_decorator.rb
+++ b/app/decorators/cloud_object_store_container_decorator.rb
@@ -3,7 +3,7 @@ class CloudObjectStoreContainerDecorator < MiqDecorator
     'ff ff-cloud-object-store'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_object_store_object_decorator.rb
+++ b/app/decorators/cloud_object_store_object_decorator.rb
@@ -3,7 +3,7 @@ class CloudObjectStoreObjectDecorator < MiqDecorator
     'ff ff-cloud-object-store'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_subnet_decorator.rb
+++ b/app/decorators/cloud_subnet_decorator.rb
@@ -3,7 +3,7 @@ class CloudSubnetDecorator < MiqDecorator
     'pficon pficon-network'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_tenant_decorator.rb
+++ b/app/decorators/cloud_tenant_decorator.rb
@@ -3,7 +3,7 @@ class CloudTenantDecorator < MiqDecorator
     'pficon pficon-cloud-tenant'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_volume_backup_decorator.rb
+++ b/app/decorators/cloud_volume_backup_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeBackupDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_volume_decorator.rb
+++ b/app/decorators/cloud_volume_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_volume_snapshot_decorator.rb
+++ b/app/decorators/cloud_volume_snapshot_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeSnapshotDecorator < MiqDecorator
     'fa fa-camera'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/cloud_volume_type_decorator.rb
+++ b/app/decorators/cloud_volume_type_decorator.rb
@@ -3,7 +3,7 @@ class CloudVolumeTypeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/configuration_profile_decorator.rb
+++ b/app/decorators/configuration_profile_decorator.rb
@@ -7,7 +7,7 @@ class ConfigurationProfileDecorator < MiqDecorator
     end
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/configuration_script_source_decorator.rb
+++ b/app/decorators/configuration_script_source_decorator.rb
@@ -3,7 +3,7 @@ class ConfigurationScriptSourceDecorator < MiqDecorator
     "pficon pficon-repository"
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -3,7 +3,7 @@ class ConfiguredSystemDecorator < MiqDecorator
     'ff ff-configured-system'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_build_decorator.rb
+++ b/app/decorators/container_build_decorator.rb
@@ -3,7 +3,7 @@ class ContainerBuildDecorator < MiqDecorator
     'pficon pficon-build'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_decorator.rb
+++ b/app/decorators/container_decorator.rb
@@ -3,7 +3,7 @@ class ContainerDecorator < MiqDecorator
     'fa fa-cube'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_group_decorator.rb
+++ b/app/decorators/container_group_decorator.rb
@@ -3,7 +3,7 @@ class ContainerGroupDecorator < MiqDecorator
     'fa fa-cubes'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_image_decorator.rb
+++ b/app/decorators/container_image_decorator.rb
@@ -3,7 +3,7 @@ class ContainerImageDecorator < MiqDecorator
     'pficon pficon-image'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_image_registry_decorator.rb
+++ b/app/decorators/container_image_registry_decorator.rb
@@ -3,7 +3,7 @@ class ContainerImageRegistryDecorator < MiqDecorator
     'pficon pficon-registry'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_node_decorator.rb
+++ b/app/decorators/container_node_decorator.rb
@@ -3,7 +3,7 @@ class ContainerNodeDecorator < MiqDecorator
     'pficon pficon-container-node'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_project_decorator.rb
+++ b/app/decorators/container_project_decorator.rb
@@ -3,7 +3,7 @@ class ContainerProjectDecorator < MiqDecorator
     'pficon pficon-project'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_replicator_decorator.rb
+++ b/app/decorators/container_replicator_decorator.rb
@@ -3,7 +3,7 @@ class ContainerReplicatorDecorator < MiqDecorator
     'pficon pficon-replicator'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_route_decorator.rb
+++ b/app/decorators/container_route_decorator.rb
@@ -3,7 +3,7 @@ class ContainerRouteDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_service_decorator.rb
+++ b/app/decorators/container_service_decorator.rb
@@ -3,7 +3,7 @@ class ContainerServiceDecorator < MiqDecorator
     'pficon pficon-service'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_template_decorator.rb
+++ b/app/decorators/container_template_decorator.rb
@@ -3,7 +3,7 @@ class ContainerTemplateDecorator < MiqDecorator
     'pficon pficon-template'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/container_volume_decorator.rb
+++ b/app/decorators/container_volume_decorator.rb
@@ -3,7 +3,7 @@ class ContainerVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/ems_cluster_decorator.rb
+++ b/app/decorators/ems_cluster_decorator.rb
@@ -3,7 +3,7 @@ class EmsClusterDecorator < MiqDecorator
     'pficon pficon-cluster'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -11,7 +11,7 @@ class ExtManagementSystemDecorator < MiqDecorator
     "svg/vendor-#{image_name}.svg"
   end
 
-  def single_quad
+  def quadicon
     {
       :fileicon => fileicon
     }

--- a/app/decorators/flavor_decorator.rb
+++ b/app/decorators/flavor_decorator.rb
@@ -3,7 +3,7 @@ class FlavorDecorator < MiqDecorator
     'pficon pficon-flavor'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/floating_ip_decorator.rb
+++ b/app/decorators/floating_ip_decorator.rb
@@ -3,7 +3,7 @@ class FloatingIpDecorator < MiqDecorator
     'ff ff-floating-ip'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/host_aggregate_decorator.rb
+++ b/app/decorators/host_aggregate_decorator.rb
@@ -3,7 +3,7 @@ class HostAggregateDecorator < MiqDecorator
     'pficon pficon-container-node'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/load_balancer_decorator.rb
+++ b/app/decorators/load_balancer_decorator.rb
@@ -3,7 +3,7 @@ class LoadBalancerDecorator < MiqDecorator
     'ff ff-load-balancer'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       'pficon pficon-template'
     end
 
-    def single_quad
+    def quadicon
       {
         :fonticon => fonticon
       }

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::AnsibleTower
       'ff ff-stack'
     end
 
-    def single_quad
+    def quadicon
       {
         :fonticon => fonticon
       }

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::AnsibleTower
       'svg/vendor-ansible.svg'
     end
 
-    def single_quad
+    def quadicon
       {
         :fileicon => fileicon
       }

--- a/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'pficon pficon-folder-close'
     end
 
-    def single_quad
+    def quadicon
       {
         :fonticon => fonticon
       }

--- a/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'pficon pficon-folder-close'
     end
 
-    def single_quad
+    def quadicon
       {
         :fonticon => fonticon
       }

--- a/app/decorators/manageiq/providers/configuration_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/configuration_manager_decorator.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers
       "svg/vendor-#{image_name.downcase}.svg"
     end
 
-    def single_quad
+    def quadicon
       {
         :fileicon => fileicon
       }

--- a/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::EmbeddedAnsible
       'svg/vendor-ansible.svg'
     end
 
-    def single_quad
+    def quadicon
       {
         :fileicon => fileicon
       }

--- a/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       'pficon pficon-locked'
     end
 
-    def single_quad
+    def quadicon
       {
         :fonticon => fonticon
       }

--- a/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers
       "pficon pficon-repository"
     end
 
-    def single_quad
+    def quadicon
       {
         :fonticon => fonticon
       }

--- a/app/decorators/network_port_decorator.rb
+++ b/app/decorators/network_port_decorator.rb
@@ -3,7 +3,7 @@ class NetworkPortDecorator < MiqDecorator
     'ff ff-network-port'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/network_router_decorator.rb
+++ b/app/decorators/network_router_decorator.rb
@@ -3,7 +3,7 @@ class NetworkRouterDecorator < MiqDecorator
     'pficon pficon-route'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/orchestration_stack_decorator.rb
+++ b/app/decorators/orchestration_stack_decorator.rb
@@ -3,7 +3,7 @@ class OrchestrationStackDecorator < MiqDecorator
     'ff ff-stack'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/orchestration_template_decorator.rb
+++ b/app/decorators/orchestration_template_decorator.rb
@@ -3,7 +3,7 @@ class OrchestrationTemplateDecorator < MiqDecorator
     'pficon pficon-template'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/persistent_volume_decorator.rb
+++ b/app/decorators/persistent_volume_decorator.rb
@@ -3,7 +3,7 @@ class PersistentVolumeDecorator < MiqDecorator
     'pficon pficon-volume'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/physical_rack_decorator.rb
+++ b/app/decorators/physical_rack_decorator.rb
@@ -3,7 +3,7 @@ class PhysicalRackDecorator < MiqDecorator
     'pficon pficon-enterprise'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon,
     }

--- a/app/decorators/physical_storage_decorator.rb
+++ b/app/decorators/physical_storage_decorator.rb
@@ -3,7 +3,7 @@ class PhysicalStorageDecorator < MiqDecorator
     'pficon pficon-container-node'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon,
       :tooltip  => ui_lookup(:model => type),

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -7,7 +7,7 @@ class ResourcePoolDecorator < MiqDecorator
     vapp ? 'svg/vendor-vmware.svg' : nil
   end
 
-  def single_quad
+  def quadicon
     {
       :fileicon => fileicon,
       :fonticon => fileicon ? nil : fonticon

--- a/app/decorators/security_group_decorator.rb
+++ b/app/decorators/security_group_decorator.rb
@@ -3,7 +3,7 @@ class SecurityGroupDecorator < MiqDecorator
     'pficon pficon-cloud-security'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -7,7 +7,7 @@ class ServiceDecorator < MiqDecorator
     try(:picture) ? "/pictures/#{picture.basename}" : nil
   end
 
-  def single_quad
+  def quadicon
     fileicon ? {:fileicon => fileicon} : {:fonticon => fonticon}
   end
 end

--- a/app/decorators/service_template_catalog_decorator.rb
+++ b/app/decorators/service_template_catalog_decorator.rb
@@ -3,7 +3,7 @@ class ServiceTemplateCatalogDecorator < MiqDecorator
     'pficon pficon-folder-close'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -11,7 +11,7 @@ class ServiceTemplateDecorator < MiqDecorator
     try(:picture) ? "/pictures/#{picture.basename}" : nil
   end
 
-  def single_quad
+  def quadicon
     fileicon ? {:fileicon => fileicon} : {:fonticon => fonticon}
   end
 end

--- a/app/decorators/switch_decorator.rb
+++ b/app/decorators/switch_decorator.rb
@@ -3,7 +3,7 @@ class SwitchDecorator < MiqDecorator
     'ff ff-network-switch'
   end
 
-  def single_quad
+  def quadicon
     {
       :fonticon => fonticon
     }

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -115,8 +115,7 @@ module QuadiconHelper
   end
 
   def quadicon_hash(item)
-    # Try to build the quadicon and if not available, fall back to single_quad
-    quad_icon = item.try(:decorate).try(:quadicon) || item.try(:decorate).try(:single_quad)
+    quad_icon = item.try(:decorate).try(:quadicon) # Try to build the quadicon
 
     # Alter the quadicon's bottom-right quadrant on the policy simulation screen
     if !!@policy_sim && session[:policies].present?


### PR DESCRIPTION
As we [got rid of the possibility to choose](https://github.com/ManageIQ/manageiq-ui-classic/pull/6255) between `single_quad` and `quadicon` for individual users, there's no point to keep the definitions separately. This will allow us to clean up the quadicon selection process a little.

Parent issue https://github.com/ManageIQ/manageiq-design/issues/43
Updated guides: https://github.com/ManageIQ/guides/pull/386