### PR TITLE
Add gtl_button_cell to ServiceTemplateDecorator for valid/invalid Service

### DIFF
--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -14,4 +14,16 @@ class ServiceTemplateDecorator < MiqDecorator
   def quadicon
     fileicon ? {:fileicon => fileicon} : {:fonticon => fonticon}
   end
+
+  def gtl_button_cell
+    v = template_valid?
+    {
+      :is_button => true,
+      :text      => _("Order"),
+      :title     => t = v ? _("Order this Service") : _("This Service cannot be ordered"),
+      :alt       => t,
+      :disabled  => !v,
+      :onclick   => "miqOrderService(\"#{id}\");"
+    }
+  end
 end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6320

We need this PR for identifying invalid Catalog Items/Bundles in the UI. See the [comment](https://github.com/ManageIQ/manageiq-ui-classic/pull/6448#discussion_r359169795).