### PR TITLE
removed symlinks to vendor for the providers

### DIFF
--- a/app/assets/images/svg/vendor-ibm_cloud_network.svg
+++ b/app/assets/images/svg/vendor-ibm_cloud_network.svg
@@ -1,1 +1,0 @@
-vendor-ibm.svg

--- a/app/assets/images/svg/vendor-ibm_cloud_power_virtual_servers.svg
+++ b/app/assets/images/svg/vendor-ibm_cloud_power_virtual_servers.svg
@@ -1,1 +1,0 @@
-vendor-ibm.svg

--- a/app/assets/images/svg/vendor-ibm_cloud_storage.svg
+++ b/app/assets/images/svg/vendor-ibm_cloud_storage.svg
@@ -1,1 +1,0 @@
-vendor-ibm.svg


### PR DESCRIPTION
it was decided to reference the corresp. images
from the code, by implementing the 'image_name' method
providers will all now reference the IBM vendor image from code