### PR TITLE
Adding decorator for host_initiator

### DIFF
--- a/app/decorators/host_initiator_decorator.rb
+++ b/app/decorators/host_initiator_decorator.rb
@@ -1,0 +1,11 @@
+class HostInitiatorDecorator < MiqDecorator
+def self.fonticon
+    'pficon pficon-virtual-machine'
+  end
+
+  def quadicon
+    {
+      :fonticon => fonticon,
+    }
+  end
+end


### PR DESCRIPTION
Host Initiators (AKA physical storage hosts) are virtual entities that only exists as a set of definitions within the `PhysicalStorage' and hold the information about consumers/hosts that use (defined) the physical storage.

This PR includes the work for adding decorators for host initiators.
It will be used to show host-initiators in block-storage dashboard

![Screenshot 2021-01-17 060105](https://user-images.githubusercontent.com/53213107/104830663-6f89d580-5889-11eb-9ba9-749544904683.jpg)
![Screenshot 2021-01-17 060009](https://user-images.githubusercontent.com/53213107/104830664-70bb0280-5889-11eb-87d1-9ec731ce4eff.jpg)


links
------
https://github.com/ManageIQ/manageiq-ui-classic/pull/7586