### PR TITLE
Add Icon for Amazon EKS

### DIFF
--- a/app/assets/images/svg/vendor-eks.svg
+++ b/app/assets/images/svg/vendor-eks.svg
@@ -1,0 +1,1 @@
+vendor-amazon.svg


### PR DESCRIPTION
Symlinked to the vendor-ec2.svg as the icon is for all Amazon Web Services

![Screenshot from 2021-02-08 12-50-25](https://user-images.githubusercontent.com/12851112/107260636-50a3dc80-6a0c-11eb-800f-d74a795d087b.png)


https://github.com/ManageIQ/manageiq-providers-amazon/issues/682