### PR TITLE
Add symbolic links for PowerVC child manager icons

### DIFF
--- a/app/assets/images/svg/vendor-ibm_power_vc_cinder.svg
+++ b/app/assets/images/svg/vendor-ibm_power_vc_cinder.svg
@@ -1,0 +1,1 @@
+vendor-ibm_power_vc.svg

--- a/app/assets/images/svg/vendor-ibm_power_vc_network.svg
+++ b/app/assets/images/svg/vendor-ibm_power_vc_network.svg
@@ -1,0 +1,1 @@
+vendor-ibm_power_vc.svg

--- a/app/assets/images/svg/vendor-ibm_power_vc_swift.svg
+++ b/app/assets/images/svg/vendor-ibm_power_vc_swift.svg
@@ -1,0 +1,1 @@
+app/assets/images/svg/vendor-ibm_power_vc.svg


### PR DESCRIPTION
Fixes empty PowerVC storage and network manager icons.