### PR TITLE
Remove IBM PowerVC switch icon

### DIFF
--- a/app/assets/images/svg/vendor-ibm_power_vc_swift.svg
+++ b/app/assets/images/svg/vendor-ibm_power_vc_swift.svg
@@ -1,1 +1,0 @@
-app/assets/images/svg/vendor-ibm_power_vc.svg


### PR DESCRIPTION
The Swift storage manager has been disabled in the IBM PowerVC plugin _master_ branch (https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/commit/0994a28f).