### PR TITLE
Use host vendor type to generate fileicon path

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -4,7 +4,7 @@ class HostDecorator < MiqDecorator
   end
 
   def fileicon
-    "svg/vendor-#{vmm_vendor_display.downcase}.svg"
+    "svg/vendor-#{vmm_vendor.downcase}.svg"
   end
 
   def quadicon


### PR DESCRIPTION
Host 'vmm_vendor_display' value should be used for UI display only. The
'vmm_vendor' value shouldn't have spaces, etc. VM fileicon paths are
already generated this way.