### PR TITLE
Fix for error when opening C&U Collection

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -4,7 +4,7 @@ class HostDecorator < MiqDecorator
   end
 
   def fileicon
-    "svg/vendor-#{vmm_vendor.downcase}.svg"
+    "svg/vendor-#{vmm_vendor.downcase}.svg" if vmm_vendor.present?
   end
 
   def quadicon


### PR DESCRIPTION
Settings > C&U Collections tab

Fixes : https://github.ibm.com/katamari/dev-issue-tracking/issues/30018

**Before**
Error dialog was displayed
<img width="912" alt="image" src="https://user-images.githubusercontent.com/87487049/170713038-fe568cd4-821e-471b-9f1b-9beb3e9e936f.png">

**After**
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/87487049/170713651-dd1da455-d377-4630-860d-9acddaa2c4fd.png">

default icon displayed if not available
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/87487049/170712133-af34b871-eae2-426e-b35a-ce2738d30d5d.png">

@miq-bot add-reviewer @Fryguy 
@miq-bot add-label bug
@miq-bot assign @Fryguy

