### PR TITLE
decorators of host initiator group and volume mapping

### DIFF
--- a/app/decorators/host_initiator_group_decorator.rb
+++ b/app/decorators/host_initiator_group_decorator.rb
@@ -1,6 +1,6 @@
-class VolumeMappingDecorator < MiqDecorator
+class HostInitiatorGroupDecorator < MiqDecorator
   def self.fonticon
-    'pficon pficon-topology'
+    'ff ff-relationship'
   end
 
   def quadicon


### PR DESCRIPTION
added decorator for host initiator group and adjusted that of volume mapping to the new icon.

related ui PRs:
open: https://github.com/ManageIQ/manageiq-ui-classic/pull/8612
merged: https://github.com/ManageIQ/manageiq-ui-classic/pull/8593

**before:**

![](https://user-images.githubusercontent.com/106743023/214306071-06bf44d4-4234-498e-bdad-16660b82a044.png)

===
---

**after:**

<img width="367" alt="image" src="https://user-images.githubusercontent.com/106743023/214538148-8b64549a-2c69-408c-9051-0b62b3ac8e68.png">

